### PR TITLE
Provide a simpler and safer way to name emitters

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,17 +19,10 @@ var EmitLogger = require('emit-logger');
 var logger = new EmitLogger();
 
 var emitter1 = new Emitter();
-emitter1.toString = function() {
-  return 'emitter 1';
-};
-
 var emitter2 = new Emitter();
-emitter2.toString = function() {
-  return 'emitter 2';
-};
 
-logger.add(emitter1);
-logger.add(emitter2);
+logger.add(emitter1, { name: 'emitter1' });
+logger.add(emitter2, { name: 'emitter2' });
 
 emitter1.on('foo', function() {
   console.log('foo!');

--- a/examples/index.js
+++ b/examples/index.js
@@ -4,17 +4,10 @@ var EmitLogger = require('../');
 var logger = new EmitLogger();
 
 var emitter1 = new Emitter();
-emitter1.toString = function() {
-  return 'emitter 1';
-};
-
 var emitter2 = new Emitter();
-emitter2.toString = function() {
-  return 'emitter 2';
-};
 
-logger.add(emitter1);
-logger.add(emitter2);
+logger.add(emitter1, { name: 'emitter1' });
+logger.add(emitter2, { name: 'emitter2' });
 
 emitter1.on('foo', function() {
   console.log('foo!');

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ EmitLogger.prototype.__proto__ = Emitter.prototype;
  * @param {EventEmitter} emitter
  */
 
-EmitLogger.prototype.add = function(emitter) {
+EmitLogger.prototype.add = function(emitter, _options) {
+  var options = _options || {};
   var self = this;
   var emit = emitter.emit;
 
@@ -47,7 +48,7 @@ EmitLogger.prototype.add = function(emitter) {
 
   emitter.emit = function() {
     var args = [].slice.call(arguments);
-    self._store.add(emitter, args);
+    self._store.add(emitter, args, options);
     return emit.apply(emitter, arguments);
   };
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,9 +1,10 @@
-
 /**
  * Module dependencies.
  */
 
+var chalk = require('chalk');
 var inspect = require('util').inspect;
+var moment = require('moment');
 
 /**
  * Expose `Store`.
@@ -24,8 +25,17 @@ function Store(options) {
  * @param {Array} args
  */
 
-Store.prototype.add = function(emitter, args) {
-  console.log('\u001b[90m [emit-logger] %s \u001b[36m%s \u001b[90memitting\u001b[32m %s\u001b[0m:',
-    +new Date(), emitter, args.shift(), inspect(args, { colors: true }));
+Store.prototype.add = function(emitter, args, _options) {
+  var options = _options || {};
+
+  console.log(
+    '%s %s %s emitting %s:',
+    chalk.gray('[emit-logger]'),
+    chalk.gray(moment().format('HH:mm:ss.SSS')),
+    chalk.cyan(options.name || emitter),
+    chalk.green(args.shift()),
+    inspect(args, { colors: true })
+  );
+
   return this;
 };

--- a/package.json
+++ b/package.json
@@ -1,12 +1,24 @@
 {
   "name": "emit-logger",
+  "main": "index.js",
   "version": "0.1.0",
   "description": "event logger for EventEmitter",
-  "keywords": ["EventEmitter", "event", "log", "logging", "logger"],
+  "keywords": [
+    "EventEmitter",
+    "event",
+    "log",
+    "logging",
+    "logger"
+  ],
   "contributors": [
-    { "name": "Seiya Konno", "email": "nulltask@gmail.com" }
+    {
+      "name": "Seiya Konno",
+      "email": "nulltask@gmail.com"
+    }
   ],
   "dependencies": {
+    "chalk": "^1.1.1",
+    "moment": "^2.10.6"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
This PR:
- makes emitter naming simpler and safer by allowing the name to be passed as an option to `EmitLogger.add`
- makes the output formatting easier to read/maintain by using [chalk](https://www.npmjs.com/package/chalk)
- uses [moment](https://www.npmjs.com/package/moment) to display the time in a more readable format
